### PR TITLE
Fix kivy.uix.widget.WidgetException: Cannot add <behaviors.modal_cursor.CursorModalView> to window, it already has a parent <kivy.core.window.window_sdl2.WindowSDL>

### DIFF
--- a/behaviors/modal_cursor.py
+++ b/behaviors/modal_cursor.py
@@ -4,7 +4,7 @@ from kivy.uix.modalview import ModalView
 from kivy.graphics import Rectangle
 from kivy.core.window import Window
 from kivy.uix.widget import Widget
-from kivy.metrics import dp, cm
+from kivy.metrics import dp
 from time import time
 import os
 path = os.path.split(os.path.realpath(__file__))[0]
@@ -25,14 +25,13 @@ class CursorModalView(ModalView):
         self.pos = (-9999, -9999)
         self.cursor = ResizeCursor()
         self.add_widget(self.cursor)
-        self.open()
+        self._cursor_has_already_added = False
 
     def open(self, *largs):
-        self._window = self._search_window()
-        if not self._window:
-            Logger.warning('ModalView: cannot open view, no window found.')
-            return
-        self._window.add_widget(self)
+        if not self._cursor_has_already_added:
+            from kivy.app import App
+            App.get_running_app().root.add_widget(self)
+            self._cursor_has_already_added = True
 
     def put_on_top(self, *args):
         self.dismiss()

--- a/examples/resizable_widget_application.py
+++ b/examples/resizable_widget_application.py
@@ -6,19 +6,19 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.label import Label
 from kivy.uix.button import Button
 from kivy.metrics import cm
-from kivy.core.window import Window
 from kivy.properties import ListProperty
 from kivy.graphics import *
-from kivy.clock import Clock
 from os import sys, path
+
 sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+
 from behaviors import ResizableBehavior
 from kivy.lang import Builder
 
 
 def from_rgb(r, g, b):
     r, g, b = float(r), float(g), float(b)
-    return [r / 255.0,g / 255.0,b / 255.0, 1]
+    return [r / 255.0, g / 255.0, b / 255.0, 1]
 
 
 class ResizableLabel(ResizableBehavior, Label):
@@ -52,7 +52,8 @@ class ResizableSideBar(ResizableBehavior, BoxLayout):
 
     def after_init(self):
         for x in range(1, 10):
-            lbl = Label(size_hint=(1, None), height=(cm(1)), text='X '+str(x))
+            lbl = Label(size_hint=(1, None), height=(cm(1)),
+                        text='X ' + str(x))
             self.add_widget(lbl)
         self.bind(size=lambda obj, val: setattr(
             self.background, 'size', self.size))
@@ -67,6 +68,7 @@ class ResizableSideBar(ResizableBehavior, BoxLayout):
 
 class ResizableStackLayout(ResizableBehavior, StackLayout):
     bgcl = ListProperty([1, 1, 1, 1])
+
     def __init__(self, bgcl, **kwargs):
         super(ResizableStackLayout, self).__init__(**kwargs)
         self.bgcl = bgcl
@@ -86,7 +88,7 @@ class ResizableWidgetDemo(FloatLayout):
         self.sidebar = ResizableSideBar(
             size_hint=(None, 1), width=cm(4.5), orientation='vertical')
         self.stack1 = StackLayout(
-            size_hint=(None, 1), width=self.width-cm(4.5))
+            size_hint=(None, 1), width=self.width - cm(4.5))
         self.stack2 = ResizableStackLayout(
             # [0.8, 0.33, 0.33, 1], size_hint=(1, None),
             # height=cm(5), resizable_down=True)
@@ -96,30 +98,30 @@ class ResizableWidgetDemo(FloatLayout):
             from_rgb(42, 49, 50), size_hint=(1, None))
         rbutton = ResizableButton(
             text='down, left resizable button \n in resizable stacklayout',
-            resizable_right = True,
-            resizable_down = True,
+            resizable_right=True,
+            resizable_down=True,
             size_hint=(None, None),
             size=(cm(6), cm(4)),
             on_release=lambda x: print('ON_RELASE()')
         )
         sidelabel = ResizableLabel(
             text='Reizable button \nin resizable sidebar',
-            resizable_down = True,
+            resizable_down=True,
             size_hint=(1, None),
             height=cm(1),
         )
         r4sides = ResizableButton(
             text='4 sides resizable,\n floating button\n with size limit',
-            resizable_right = True,
-            resizable_left = True,
-            resizable_up = True,
-            resizable_down = True,
+            resizable_right=True,
+            resizable_left=True,
+            resizable_up=True,
+            resizable_down=True,
             size_hint=(None, None),
             min_resizable_width=cm(3),
             min_resizable_height=cm(3),
             max_resizable_width=cm(10),
             max_resizable_height=cm(10),
-            resizable_border_offset = 14,
+            resizable_border_offset=14,
             size=(cm(6), cm(6)),
             on_release=lambda x: print('ON_RELASE()')
         )
@@ -155,7 +157,11 @@ Builder.load_string('''
         Color:
             rgba: 0.3, 0.25, 0.2, 1
         Line:
-            points: self.x, self.y, self.x, self.top, self.right, self.top, self.right, self.y, self.x, self.y
+            points:
+                self.x, self.y, self.x, self.top, \
+                self.right, self.top, self.right, \
+                self.y, self.x, self.y
 ''')
+
 if __name__ == '__main__':
     ResizableWidgetDemoApp().run()


### PR DESCRIPTION
After running garden.resizable_behavior/examples/resizable_widget_application.py getting error:

```python
 Traceback (most recent call last):
   File "/Users/macbookair/Projects/Master/garden.resizable_behavior/examples/resizable_widget_application.py", line 167, in <module>
     ResizableWidgetDemoApp().run()
   File "/Users/macbookair/Opt/Kivy3/Contents/Frameworks/python/3.6.5/lib/python3.6/site-packages/kivy/app.py", line 826, in run
     runTouchApp()
   File "/Users/macbookair/Opt/Kivy3/Contents/Frameworks/python/3.6.5/lib/python3.6/site-packages/kivy/base.py", line 502, in runTouchApp
     EventLoop.window.mainloop()
   File "/Users/macbookair/Opt/Kivy3/Contents/Frameworks/python/3.6.5/lib/python3.6/site-packages/kivy/core/window/window_sdl2.py", line 727, in mainloop
     self._mainloop()
   File "/Users/macbookair/Opt/Kivy3/Contents/Frameworks/python/3.6.5/lib/python3.6/site-packages/kivy/core/window/window_sdl2.py", line 460, in _mainloop
     EventLoop.idle()
   File "/Users/macbookair/Opt/Kivy3/Contents/Frameworks/python/3.6.5/lib/python3.6/site-packages/kivy/base.py", line 337, in idle
     Clock.tick()
   File "/Users/macbookair/Opt/Kivy3/Contents/Frameworks/python/3.6.5/lib/python3.6/site-packages/kivy/clock.py", line 581, in tick
     self._process_events()
   File "kivy/_clock.pyx", line 384, in kivy._clock.CyClockBase._process_events
   File "kivy/_clock.pyx", line 414, in kivy._clock.CyClockBase._process_events
   File "kivy/_clock.pyx", line 412, in kivy._clock.CyClockBase._process_events
   File "kivy/_clock.pyx", line 167, in kivy._clock.ClockEvent.tick
   File "/Users/macbookair/Projects/Master/garden.resizable_behavior/behaviors/modal_cursor.py", line 39, in put_on_top
     self.open()
   File "/Users/macbookair/Projects/Master/garden.resizable_behavior/behaviors/modal_cursor.py", line 35, in open
     self._window.add_widget(self)
   File "/Users/macbookair/Opt/Kivy3/Contents/Frameworks/python/3.6.5/lib/python3.6/site-packages/kivy/core/window/__init__.py", line 1255, in add_widget
     (widget, widget.parent)
 kivy.uix.widget.WidgetException: Cannot add <behaviors.modal_cursor.CursorModalView object at 0x1026fa590> to window, it already has a parent <kivy.core.window.window_sdl2.WindowSDL object at 0x1026bfb40>
```